### PR TITLE
Build on windows, update Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  DisplayCopNames: true
+
 ## Styles ######################################################################
 
 Style/AlignParameters:
@@ -31,17 +34,11 @@ Style/Lambda:
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-# A bit useless restriction, that makes impossible aligning code like this:
-#
-#   redis do |conn|
-#     conn.hset    :k1, now
-#     conn.hincrby :k2, 123
-#   end
-SingleSpaceBeforeFirstArg:
-  Enabled: false
-
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/EmptyCaseCondition:
+  Enabled: false
 
 # Not all trivial readers/writers can be defined with attr_* methods
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-19mode
-  - jruby-head
-  - rbx-2
-  - ruby-head
+  - 2.3.0
+  - 2.4.0
+  - jruby-9.1.6.0
 matrix:
-  allow_failures:
-    - rvm: jruby-head
-    - rvm: ruby-head
   fast_finish: true
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem "coveralls"
   gem "rspec",      "~> 3.1"
   gem "simplecov",  ">= 0.9"
-  gem "rubocop",    "~> 0.28.0"
+  gem "rubocop",    "= 0.40.0"
 end
 
 group :doc do

--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ socket << form.to_s
 This library aims to support and is [tested against][ci] the following Ruby
 versions:
 
-* Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1.x
 * Ruby 2.2.x
+* Ruby 2.3.x
+* JRuby 9.1.6.0
 
 If something doesn't work on one of these versions, it's a bug.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+version: "#{build}"
+build: off
+install:
+  - set PATH=C:\Ruby23\bin;%PATH%
+  - bundle install
+test_script:
+  - bundle exec rake
+skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: "#{build}"
 build: off
+init:
+  - git config --global core.autocrlf true
 install:
   - set PATH=C:\Ruby23\bin;%PATH%
   - bundle install

--- a/http-form_data.gemspec
+++ b/http-form_data.gemspec
@@ -11,15 +11,15 @@ Gem::Specification.new do |spec|
   spec.email         = ["ixti@member.fsf.org"]
   spec.license       = "MIT"
   spec.summary       = "http-form_data-#{HTTP::FormData::VERSION}"
-  spec.description   = <<-DESC.gsub(/^\s+> /m, "").gsub("\n", " ").strip
+  spec.description   = <<-DESC.gsub(/^\s+> /m, "").tr("\n", " ").strip
   > Utility-belt to build form data request bodies.
   > Provides support for `application/x-www-form-urlencoded` and
   > `multipart/form-data` types.
   DESC
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(/^bin\//).map { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin\/}).map { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)\/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -55,7 +55,7 @@ module HTTP
         when obj.nil?               then {}
         when obj.is_a?(Hash)        then obj
         when obj.respond_to?(:to_h) then obj.to_h
-        else fail Error, "#{obj.inspect} is neither Hash nor responds to :to_h"
+        else raise Error, "#{obj.inspect} is neither Hash nor responds to :to_h"
         end
       end
 

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -67,7 +67,7 @@ module HTTP
         if @file_or_io.is_a?(::File) || @file_or_io.is_a?(StringIO)
           yield @file_or_io
         else
-          ::File.open(@file_or_io) { |io| yield io }
+          ::File.open(@file_or_io, "rb") { |io| yield io }
         end
       end
     end

--- a/lib/http/form_data/multipart/param.rb
+++ b/lib/http/form_data/multipart/param.rb
@@ -6,7 +6,8 @@ module HTTP
         # @param [#to_s] name
         # @param [FormData::File, #to_s] value
         def initialize(name, value)
-          @name, @value = name.to_s, value
+          @name = name.to_s
+          @value = value
 
           @header = "Content-Disposition: form-data; name=#{@name.inspect}"
 

--- a/lib/http/form_data/version.rb
+++ b/lib/http/form_data/version.rb
@@ -1,6 +1,6 @@
 module HTTP
   module FormData
     # Gem version.
-    VERSION = "1.0.1"
+    VERSION = "1.0.1".freeze
   end
 end

--- a/spec/lib/http/form_data/file_spec.rb
+++ b/spec/lib/http/form_data/file_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe HTTP::FormData::File do
 
     context "when file given as a String" do
       let(:file) { fixture("the-http-gem.info").to_s }
-      it { is_expected.to eq fixture("the-http-gem.info").read }
+      it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
     end
 
     context "when file given as StringIO" do
@@ -37,9 +37,9 @@ RSpec.describe HTTP::FormData::File do
     end
 
     context "when file given as File" do
-      let(:file) { fixture("the-http-gem.info").open }
+      let(:file) { fixture("the-http-gem.info").open("rb") }
       after { file.close }
-      it { is_expected.to eq fixture("the-http-gem.info").read }
+      it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
     end
   end
 

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe HTTP::FormData::Multipart do
 
   describe "#content_type" do
     subject { form_data.content_type }
-    it { is_expected.to match(/^multipart\/form-data; boundary=#{boundary}$/) }
+
+    let(:content_type) { %r{^multipart\/form-data; boundary=#{boundary}$} }
+
+    it { is_expected.to match(content_type) }
   end
 
   describe "#content_length" do


### PR DESCRIPTION
When running tests on Windows machine with git config `core.autocrlf` set to `true` I got a failing test about content_length.

That was because `::File#size` on Windows returns an actual file size (with CRLF line endings) but `to_s` used to read file in a text mode that converts CRLF into LF. Please read general info about this issue [here]( https://www.rubytapas.com/2016/12/14/ruby-code-on-windows/) if you want.

I set `core.autocrlf` to `true` in AppVeyor configuration as this setting is recommended by [Github](https://help.github.com/articles/dealing-with-line-endings/#platform-windows) and [Git book](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#Formatting-and-Whitespace). Also it allowed to reproduce an issue there.

In addition, I updated Rubocop to 0.40.0 as old version didn't support a new Rake version. 0.40.0 is used in httprb/http repository.

cc @ixti, @tarcieri as Tony is a watcher in http repository but not here

Here is a build status in my fork - https://ci.appveyor.com/project/abotalov/form-data-rb/history