### PR TITLE
RFC 7578 fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,9 @@ Metrics/MethodLength:
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Style/Alias:
+  Enabled: false
+
 Style/BracesAroundHashParameters:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,12 +21,6 @@ Style/AlignParameters:
 Style/BracesAroundHashParameters:
   Enabled: false
 
-# Broken (2014-12-15). Use `yardstick` gem instead.
-# See: https://github.com/bbatsov/rubocop/issues/947
-# TODO: Enable back once cop is fixed.
-Style/Documentation:
-  Enabled: false
-
 Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,12 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
+  - jruby-9.1.7.0
+  - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.0
-  - 2.3.1
-  - 2.3.2
   - 2.3.3
   - 2.4.0
-  - ruby-head
-  - jruby-9.1.6.0
-  - jruby-head
 matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
   fast_finish: true
 sudo: false

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ socket << "\r\n"
 socket << form.to_s
 ```
 
+It's also possible to create a non-file part with Content-Type:
+
+``` ruby
+form = HTTP::FormData.create({
+  :username     => HTTP::FormData::Part.new('{"a": 1}', content_type: 'application/json'),
+  :avatar_file  => HTTP::FormData::File.new("/home/ixti/avatar.png")
+})
+```
 
 ## Supported Ruby Versions
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ versions:
 * Ruby 2.2.x
 * Ruby 2.3.x
 * Ruby 2.4.x
-* JRuby 9.1.6.0
+* JRuby 9.1.x.x
 
 If something doesn't work on one of these versions, it's a bug.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ versions:
 * Ruby 2.1.x
 * Ruby 2.2.x
 * Ruby 2.3.x
+* Ruby 2.4.x
 * JRuby 9.1.6.0
 
 If something doesn't work on one of these versions, it's a bug.

--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -6,8 +6,8 @@ require "http/form_data/multipart"
 require "http/form_data/urlencoded"
 require "http/form_data/version"
 
-# http.rb namespace.
-# @see https://github.com/httprb/http.rb
+# http gem namespace.
+# @see https://github.com/httprb/http
 module HTTP
   # Utility-belt to build form data request bodies.
   # Provides support for `application/x-www-form-urlencoded` and

--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -70,8 +70,8 @@ module HTTP
       # @return [Boolean]
       def multipart?(data)
         data.any? do |_, v|
-          next true if v.is_a? FormData::File
-          v.respond_to?(:to_ary) && v.to_ary.any? { |e| e.is_a? FormData::File }
+          next true if v.is_a? FormData::Part
+          v.respond_to?(:to_ary) && v.to_ary.any? { |e| e.is_a? FormData::Part }
         end
       end
     end

--- a/lib/http/form_data.rb
+++ b/lib/http/form_data.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "http/form_data/part"
 require "http/form_data/file"
 require "http/form_data/multipart"
 require "http/form_data/urlencoded"

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -25,7 +25,10 @@ module HTTP
       # @see DEFAULT_MIME
       # @param [String, StringIO, File] file_or_io Filename or IO instance.
       # @param [#to_h] opts
+      # @option opts [#to_s] :content_type (DEFAULT_MIME)
+      #   Value of Content-Type header
       # @option opts [#to_s] :mime_type (DEFAULT_MIME)
+      #   Alias for :content_type
       # @option opts [#to_s] :filename
       #   When `file` is a String, defaults to basename of `file`.
       #   When `file` is a File, defaults to basename of `file`.
@@ -35,8 +38,10 @@ module HTTP
 
         opts = FormData.ensure_hash opts
 
-        @mime_type  = opts.fetch(:mime_type) { DEFAULT_MIME }
-        @filename   = opts.fetch :filename do
+        @mime_type = opts.fetch(:mime_type) do
+          opts.fetch(:content_type) { DEFAULT_MIME }
+        end
+        @filename = opts.fetch :filename do
           case file_or_io
           when String then ::File.basename file_or_io
           when ::File then ::File.basename file_or_io.path

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -18,11 +18,9 @@ module HTTP
     # @example Usage with pathname
     #
     #  FormData::File.new "/home/ixti/avatar.png"
-    class File
+    class File < Part
       # Default MIME type
       DEFAULT_MIME = "application/octet-stream"
-
-      attr_reader :mime_type, :filename
 
       # @see DEFAULT_MIME
       # @param [String, StringIO, File] file_or_io Filename or IO instance.

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -47,7 +47,7 @@ module HTTP
 
       # Returns content size.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def size
         with_io(&:size)
       end

--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -32,7 +32,7 @@ module HTTP
       # Returns form data content size to be used for HTTP request
       # `Content-Length` header.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def content_length
         unless @content_length
           @content_length  = head.bytesize + tail.bytesize

--- a/lib/http/form_data/multipart/param.rb
+++ b/lib/http/form_data/multipart/param.rb
@@ -23,9 +23,9 @@ module HTTP
 
           @header = "Content-Disposition: form-data; #{parameters}"
 
-          return unless @part.mime_type
+          return unless @part.content_type
 
-          @header += "#{CRLF}Content-Type: #{@part.mime_type}"
+          @header += "#{CRLF}Content-Type: #{@part.content_type}"
         end
 
         # Returns body part with headers and data.

--- a/lib/http/form_data/multipart/param.rb
+++ b/lib/http/form_data/multipart/param.rb
@@ -50,7 +50,7 @@ module HTTP
 
         # Calculates size of a part (headers + body).
         #
-        # @return [Fixnum]
+        # @return [Integer]
         def size
           @header.bytesize + (CRLF.bytesize * 2) + @part.size
         end

--- a/lib/http/form_data/part.rb
+++ b/lib/http/form_data/part.rb
@@ -2,15 +2,24 @@
 
 module HTTP
   module FormData
+    # Represents a body part of multipart/form-data request.
+    #
+    # @example Usage with String
+    #
+    #  body = "Message"
+    #  FormData::Part.new body, :content_type => 'foobar.txt; charset="UTF-8"'
     class Part
       attr_reader :mime_type, :filename
 
+      alias_method :content_type, :mime_type
+
       # @param [#to_s] body
-      # @param [String] :mime_type
-      # @param [String] :filename
-      def initialize(body, mime_type: nil, filename: nil)
+      # @param [String] content_type Value of Content-Type header
+      # @param [String] mime_type    Alias for content_type
+      # @param [String] filename     Value of filename parameter
+      def initialize(body, content_type: nil, mime_type: nil, filename: nil)
         @body = body.to_s
-        @mime_type = mime_type
+        @mime_type = mime_type || content_type
         @filename = filename
       end
 

--- a/lib/http/form_data/part.rb
+++ b/lib/http/form_data/part.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module HTTP
+  module FormData
+    class Part
+      attr_reader :mime_type, :filename
+
+      # @param [#to_s] body
+      # @param [String] :mime_type
+      # @param [String] :filename
+      def initialize(body, mime_type: nil, filename: nil)
+        @body = body.to_s
+        @mime_type = mime_type
+        @filename = filename
+      end
+
+      # Returns content size.
+      #
+      # @return [Integer]
+      def size
+        @body.bytesize
+      end
+
+      # Returns content of a file of IO.
+      #
+      # @return [String]
+      def to_s
+        @body
+      end
+    end
+  end
+end

--- a/lib/http/form_data/urlencoded.rb
+++ b/lib/http/form_data/urlencoded.rb
@@ -28,7 +28,7 @@ module HTTP
       # Returns form data content size to be used for HTTP request
       # `Content-Length` header.
       #
-      # @return [Fixnum]
+      # @return [Integer]
       def content_length
         to_s.bytesize
       end

--- a/spec/lib/http/form_data/file_spec.rb
+++ b/spec/lib/http/form_data/file_spec.rb
@@ -92,4 +92,12 @@ RSpec.describe HTTP::FormData::File do
       it { is_expected.to eq "application/json" }
     end
   end
+
+  describe "#content_type" do
+    it "should be an alias of #mime_type" do
+      expect(described_class.instance_method(:content_type)).to(
+        eq(described_class.instance_method(:mime_type))
+      )
+    end
+  end
 end

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -41,5 +41,21 @@ RSpec.describe HTTP::FormData::Multipart do
         "--#{boundary_value}--"
       ].join("")
     end
+
+    context "with filename set to nil" do
+      let(:part) { HTTP::FormData::Part.new("s", :filename => nil) }
+      let(:form_data) { HTTP::FormData::Multipart.new(:foo => part) }
+
+      it "doesn't include a filename" do
+        boundary_value = form_data.content_type[/(#{boundary})$/, 1]
+
+        expect(form_data.to_s).to eq [
+          "--#{boundary_value}#{crlf}",
+          "#{disposition 'name' => 'foo'}#{crlf}",
+          "#{crlf}s#{crlf}",
+          "--#{boundary_value}--"
+        ].join("")
+      end
+    end
   end
 end

--- a/spec/lib/http/form_data/part_spec.rb
+++ b/spec/lib/http/form_data/part_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe HTTP::FormData::Part do
+  let(:body) { "" }
+  let(:opts) { {} }
+
+  describe "#size" do
+    subject { described_class.new(body, opts).size }
+
+    context "when body given as a String" do
+      let(:body) { "привет мир!" }
+      it { is_expected.to eq 20 }
+    end
+  end
+
+  describe "#to_s" do
+    subject { described_class.new(body, opts).to_s }
+
+    context "when body given as String" do
+      let(:body) { "привет мир!" }
+      it { is_expected.to eq "привет мир!" }
+    end
+  end
+
+  describe "#filename" do
+    subject { described_class.new(body, opts).filename }
+
+    it { is_expected.to eq nil }
+
+    context "when it was given with options" do
+      let(:opts) { { :filename => "foobar.txt" } }
+      it { is_expected.to eq "foobar.txt" }
+    end
+  end
+
+  describe "#mime_type" do
+    subject { described_class.new(body, opts).mime_type }
+
+    it { is_expected.to eq nil }
+
+    context "when it was given with options" do
+      let(:opts) { { :mime_type => "application/json" } }
+      it { is_expected.to eq "application/json" }
+    end
+  end
+end

--- a/spec/lib/http/form_data/part_spec.rb
+++ b/spec/lib/http/form_data/part_spec.rb
@@ -43,4 +43,12 @@ RSpec.describe HTTP::FormData::Part do
       it { is_expected.to eq "application/json" }
     end
   end
+
+  describe "#content_type" do
+    it "should be an alias of #mime_type" do
+      expect(described_class.instance_method(:content_type)).to(
+        eq(described_class.instance_method(:mime_type))
+      )
+    end
+  end
 end


### PR DESCRIPTION
* Support creation of arbitrary form-data parts with Content-Type (fixes #5)
* Support creation of file parts without filename (fixes #6)
* Alias :mime_type as :content_type (because a value of Content-Type header may have charset)
