### PR TITLE
Enable request body streaming

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,12 @@ Metrics/MethodLength:
   CountComments: false
   Max: 15
 
+Metrics/CyclomaticComplexity:
+  Max: 8
+
+Metrics/PerceivedComplexity:
+  Max: 8
+
 ## Styles ######################################################################
 
 Style/AlignParameters:

--- a/lib/http/form_data/composite_io.rb
+++ b/lib/http/form_data/composite_io.rb
@@ -8,7 +8,17 @@ module HTTP
     class CompositeIO
       # @param [Array<IO>] ios Array of IO objects
       def initialize(ios)
-        @ios = ios.map { |io| io.is_a?(String) ? StringIO.new(io) : io }
+        ios = ios.map do |io|
+          if io.is_a?(String)
+            StringIO.new(io)
+          elsif io.respond_to?(:read)
+            io
+          else
+            fail ArgumentError, "#{io.inspect} is neither a String nor an IO object"
+          end
+        end
+
+        @ios = ios
         @index = 0
         @buffer = String.new
       end

--- a/lib/http/form_data/composite_io.rb
+++ b/lib/http/form_data/composite_io.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require "stringio"
+
 module HTTP
   module FormData
     # Provides IO interface across multiple IO objects.
     class CompositeIO
       # @param [Array<IO>] ios Array of IO objects
       def initialize(*ios)
-        @ios = ios.flatten
+        @ios = ios.flatten.map { |io| io.is_a?(String) ? StringIO.new(io) : io }
         @index = 0
       end
 

--- a/lib/http/form_data/composite_io.rb
+++ b/lib/http/form_data/composite_io.rb
@@ -7,8 +7,8 @@ module HTTP
     # Provides IO interface across multiple IO objects.
     class CompositeIO
       # @param [Array<IO>] ios Array of IO objects
-      def initialize(*ios)
-        @ios = ios.flatten.map { |io| io.is_a?(String) ? StringIO.new(io) : io }
+      def initialize(ios)
+        @ios = ios.map { |io| io.is_a?(String) ? StringIO.new(io) : io }
         @index = 0
         @buffer = String.new
       end

--- a/lib/http/form_data/composite_io.rb
+++ b/lib/http/form_data/composite_io.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module HTTP
+  module FormData
+    # Provides IO interface across multiple IO files.
+    class CompositeIO
+      # @param [Array<IO>] ios Array of IO objects
+      def initialize(*ios)
+        @ios = ios.flatten
+        @index = 0
+      end
+
+      # Reads and returns list of 
+      #
+      # @param [Integer] length Number of bytes to retrieve
+      # @param [String] outbuf String to be replaced with retrieved data
+      #
+      # @return [String]
+      def read(length = nil, outbuf = nil)
+        outbuf = outbuf.to_s.replace("")
+
+        while current_io
+          data = current_io.read(length)
+          outbuf << data.to_s
+          length -= data.to_s.length if length
+
+          break if length == 0
+
+          advance_io
+        end
+
+        return nil if length && outbuf.empty?
+
+        outbuf
+      end
+
+      def rewind
+        @ios.each(&:rewind)
+        @index = 0
+      end
+
+      def size
+        @size ||= @ios.map(&:size).inject(0, :+)
+      end
+
+      private
+
+      def current_io
+        @ios[@index]
+      end
+
+      def advance_io
+        @index += 1
+      end
+    end
+  end
+end

--- a/lib/http/form_data/composite_io.rb
+++ b/lib/http/form_data/composite_io.rb
@@ -2,7 +2,7 @@
 
 module HTTP
   module FormData
-    # Provides IO interface across multiple IO files.
+    # Provides IO interface across multiple IO objects.
     class CompositeIO
       # @param [Array<IO>] ios Array of IO objects
       def initialize(*ios)
@@ -10,12 +10,12 @@ module HTTP
         @index = 0
       end
 
-      # Reads and returns list of 
+      # Reads and returns partial content acrosss multiple IO objects.
       #
       # @param [Integer] length Number of bytes to retrieve
       # @param [String] outbuf String to be replaced with retrieved data
       #
-      # @return [String]
+      # @return [String, nil]
       def read(length = nil, outbuf = nil)
         outbuf = outbuf.to_s.replace("")
 
@@ -24,7 +24,7 @@ module HTTP
           outbuf << data.to_s
           length -= data.to_s.length if length
 
-          break if length == 0
+          break if length && length.zero?
 
           advance_io
         end
@@ -34,21 +34,25 @@ module HTTP
         outbuf
       end
 
+      # Returns sum of all IO sizes.
+      def size
+        @size ||= @ios.map(&:size).inject(0, :+)
+      end
+
+      # Rewinds all IO objects and set cursor to the first IO object.
       def rewind
         @ios.each(&:rewind)
         @index = 0
       end
 
-      def size
-        @size ||= @ios.map(&:size).inject(0, :+)
-      end
-
       private
 
+      # Returns IO object under the cursor.
       def current_io
         @ios[@index]
       end
 
+      # Advances cursor to the next IO object.
       def advance_io
         @index += 1
       end

--- a/lib/http/form_data/composite_io.rb
+++ b/lib/http/form_data/composite_io.rb
@@ -10,6 +10,7 @@ module HTTP
       def initialize(*ios)
         @ios = ios.flatten.map { |io| io.is_a?(String) ? StringIO.new(io) : io }
         @index = 0
+        @buffer = String.new
       end
 
       # Reads and returns partial content acrosss multiple IO objects.
@@ -22,12 +23,11 @@ module HTTP
         outbuf = outbuf.to_s.replace("")
 
         while current_io
-          if (data = current_io.read(length))
-            outbuf << data
-            length -= data.length if length
+          current_io.read(length, @buffer)
+          outbuf << @buffer
+          length -= @buffer.length if length
 
-            break if length && length.zero?
-          end
+          break if length && length.zero?
 
           advance_io
         end

--- a/lib/http/form_data/composite_io.rb
+++ b/lib/http/form_data/composite_io.rb
@@ -22,18 +22,17 @@ module HTTP
         outbuf = outbuf.to_s.replace("")
 
         while current_io
-          data = current_io.read(length)
-          outbuf << data.to_s
-          length -= data.to_s.length if length
+          if (data = current_io.read(length))
+            outbuf << data
+            length -= data.length if length
 
-          break if length && length.zero?
+            break if length && length.zero?
+          end
 
           advance_io
         end
 
-        return nil if length && outbuf.empty?
-
-        outbuf
+        outbuf unless length && outbuf.empty?
       end
 
       # Returns sum of all IO sizes.

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -31,8 +31,8 @@ module HTTP
       # @option opts [#to_s] :content_type (DEFAULT_MIME)
       #   Value of Content-Type header
       # @option opts [#to_s] :filename
-      #   When `path_or_io` is a String, Pathname or File, defaults to basename of `file`.
-      #   When `path_or_io` is a IO, defaults to `"stream-{object_id}"`
+      #   When `path_or_io` is a String, Pathname or File, defaults to basename.
+      #   When `path_or_io` is a IO, defaults to `"stream-{object_id}"`.
       def initialize(path_or_io, opts = {})
         opts = FormData.ensure_hash(opts)
 

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -26,7 +26,7 @@ module HTTP
       alias mime_type content_type
 
       # @see DEFAULT_MIME
-      # @param [String, IO] file_or_io Filename or IO instance.
+      # @param [String, Pathname, IO] file_or_io Filename or IO instance.
       # @param [#to_h] opts
       # @option opts [#to_s] :content_type (DEFAULT_MIME)
       #   Value of Content-Type header
@@ -34,7 +34,7 @@ module HTTP
       #   When `file` is a String, defaults to basename of `file`.
       #   When `file` is a File, defaults to basename of `file`.
       #   When `file` is a StringIO, defaults to `"stream-{object_id}"`
-      def initialize(file_or_io, opts = {})
+      def initialize(path_or_io, opts = {})
         opts = FormData.ensure_hash(opts)
 
         if opts.key? :mime_type
@@ -42,10 +42,10 @@ module HTTP
           opts[:content_type] = opts[:mime_type]
         end
 
-        if file_or_io.is_a?(String)
-          @io = ::File.open(file_or_io, binmode: true)
+        if path_or_io.is_a?(String) || defined?(Pathname) && path_or_io.is_a?(Pathname)
+          @io = ::File.open(path_or_io, binmode: true)
         else
-          @io = file_or_io
+          @io = path_or_io
         end
 
         @content_type = opts.fetch(:content_type, DEFAULT_MIME).to_s

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -57,20 +57,6 @@ module HTTP
           end
         end
       end
-
-      # Returns content size.
-      #
-      # @return [Integer]
-      def size
-        @io.size
-      end
-
-      # Returns content of the IO.
-      #
-      # @return [String]
-      def to_s
-        @io.read
-      end
     end
   end
 end

--- a/lib/http/form_data/file.rb
+++ b/lib/http/form_data/file.rb
@@ -43,7 +43,7 @@ module HTTP
         end
 
         if file_or_io.is_a?(String)
-          @io = ::File.open(file_or_io)
+          @io = ::File.open(file_or_io, binmode: true)
         else
           @io = file_or_io
         end

--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "securerandom"
-require "stringio"
 
 require "http/form_data/multipart/param"
 require "http/form_data/readable"
@@ -18,10 +17,7 @@ module HTTP
         parts = Param.coerce FormData.ensure_hash data
 
         @boundary = ("-" * 21) << SecureRandom.hex(21)
-        @io = CompositeIO.new(
-          *parts.flat_map { |part| [StringIO.new(glue), part] },
-          StringIO.new(tail)
-        )
+        @io = CompositeIO.new(*parts.flat_map { |part| [glue, part] }, tail)
       end
 
       # Returns MIME type to be used for HTTP request `Content-Type` header.

--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
 require "securerandom"
+require "stringio"
 
 require "http/form_data/multipart/param"
+require "http/form_data/readable"
+require "http/form_data/composite_io"
 
 module HTTP
   module FormData
     # `multipart/form-data` form data.
     class Multipart
+      include Readable
+
       # @param [#to_h, Hash] data form data key-value Hash
       def initialize(data)
-        @parts          = Param.coerce FormData.ensure_hash data
-        @boundary       = (Array.new(21, "-") << SecureRandom.hex(21)).join("")
-        @content_length = nil
-      end
+        parts = Param.coerce FormData.ensure_hash data
 
-      # Returns content to be used for HTTP request body.
-      #
-      # @return [String]
-      def to_s
-        head + @parts.map(&:to_s).join(glue) + tail
+        @boundary = ("-" * 21) << SecureRandom.hex(21)
+        @io = CompositeIO.new(
+          *parts.flat_map { |part| [StringIO.new(glue), part] },
+          StringIO.new(tail),
+        )
       end
 
       # Returns MIME type to be used for HTTP request `Content-Type` header.
@@ -34,30 +36,19 @@ module HTTP
       #
       # @return [Integer]
       def content_length
-        unless @content_length
-          @content_length  = head.bytesize + tail.bytesize
-          @content_length += @parts.map(&:size).reduce(:+)
-          @content_length += (glue.bytesize * (@parts.count - 1))
-        end
-
-        @content_length
+        size
       end
 
       private
 
       # @return [String]
-      def head
-        @head ||= "--#{@boundary}#{CRLF}"
-      end
-
-      # @return [String]
       def glue
-        @glue ||= "#{CRLF}--#{@boundary}#{CRLF}"
+        @glue ||= "--#{@boundary}#{CRLF}"
       end
 
       # @return [String]
       def tail
-        @tail ||= "#{CRLF}--#{@boundary}--"
+        @tail ||= "--#{@boundary}--"
       end
     end
   end

--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -17,7 +17,7 @@ module HTTP
         parts = Param.coerce FormData.ensure_hash data
 
         @boundary = ("-" * 21) << SecureRandom.hex(21)
-        @io = CompositeIO.new(*parts.flat_map { |part| [glue, part] }, tail)
+        @io = CompositeIO.new [*parts.flat_map { |part| [glue, part] }, tail]
       end
 
       # Returns MIME type to be used for HTTP request `Content-Type` header.

--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -20,7 +20,7 @@ module HTTP
         @boundary = ("-" * 21) << SecureRandom.hex(21)
         @io = CompositeIO.new(
           *parts.flat_map { |part| [StringIO.new(glue), part] },
-          StringIO.new(tail),
+          StringIO.new(tail)
         )
       end
 

--- a/lib/http/form_data/multipart.rb
+++ b/lib/http/form_data/multipart.rb
@@ -31,9 +31,7 @@ module HTTP
       # `Content-Length` header.
       #
       # @return [Integer]
-      def content_length
-        size
-      end
+      alias content_length size
 
       private
 

--- a/lib/http/form_data/multipart/param.rb
+++ b/lib/http/form_data/multipart/param.rb
@@ -72,7 +72,7 @@ module HTTP
         def parameters
           parameters = { :name => @name }
           parameters[:filename] = filename if filename
-          parameters = parameters.map { |k, v| "#{k}=#{v.inspect}" }.join("; ")
+          parameters.map { |k, v| "#{k}=#{v.inspect}" }.join("; ")
         end
 
         def content_type

--- a/lib/http/form_data/multipart/param.rb
+++ b/lib/http/form_data/multipart/param.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "stringio"
-
 require "http/form_data/readable"
 require "http/form_data/composite_io"
 
@@ -40,7 +38,7 @@ module HTTP
               FormData::Part.new(value)
             end
 
-          @io = CompositeIO.new(StringIO.new(header), @part, StringIO.new(footer))
+          @io = CompositeIO.new(header, @part, footer)
         end
 
         # Flattens given `data` Hash into an array of `Param`'s.

--- a/lib/http/form_data/multipart/param.rb
+++ b/lib/http/form_data/multipart/param.rb
@@ -38,7 +38,7 @@ module HTTP
               FormData::Part.new(value)
             end
 
-          @io = CompositeIO.new(header, @part, footer)
+          @io = CompositeIO.new [header, @part, footer]
         end
 
         # Flattens given `data` Hash into an array of `Param`'s.

--- a/lib/http/form_data/part.rb
+++ b/lib/http/form_data/part.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "stringio"
+
+require "http/form_data/readable"
+
 module HTTP
   module FormData
     # Represents a body part of multipart/form-data request.
@@ -9,29 +13,17 @@ module HTTP
     #  body = "Message"
     #  FormData::Part.new body, :content_type => 'foobar.txt; charset="UTF-8"'
     class Part
+      include Readable
+
       attr_reader :content_type, :filename
 
       # @param [#to_s] body
       # @param [String] content_type Value of Content-Type header
       # @param [String] filename     Value of filename parameter
       def initialize(body, content_type: nil, filename: nil)
-        @body = body.to_s
+        @io = StringIO.new(body.to_s)
         @content_type = content_type
         @filename = filename
-      end
-
-      # Returns content size.
-      #
-      # @return [Integer]
-      def size
-        @body.bytesize
-      end
-
-      # Returns content of a file of IO.
-      #
-      # @return [String]
-      def to_s
-        @body
       end
     end
   end

--- a/lib/http/form_data/readable.rb
+++ b/lib/http/form_data/readable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module HTTP
+  module FormData
+    # Common behaviour for objects defined by an IO object.
+    module Readable
+      # Returns IO content.
+      #
+      # @return [String]
+      def to_s
+        rewind
+        read
+      end
+
+      # Reads and returns part of IO content.
+      #
+      # @param [Integer] length Number of bytes to retrieve
+      # @param [String] outbuf String to be replaced with retrieved data
+      #
+      # @return [String, nil]
+      def read(length = nil, outbuf = nil)
+        @io.read(length, outbuf)
+      end
+
+      # Returns IO size.
+      #
+      # @return [Integer]
+      def size
+        @io.size
+      end
+
+      # Rewinds the IO.
+      def rewind
+        @io.rewind
+      end
+    end
+  end
+end

--- a/spec/lib/http/form_data/composite_io_spec.rb
+++ b/spec/lib/http/form_data/composite_io_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe HTTP::FormData::CompositeIO do
+  let(:ios) { ["Hello", " ", "", "world", "!"].map { |string| StringIO.new(string) } }
+  subject(:composite_io) { HTTP::FormData::CompositeIO.new *ios }
+
+  describe "#read" do
+    it "reads all data" do
+      expect(composite_io.read).to eq "Hello world!"
+    end
+
+    it "reads partial data" do
+      expect(composite_io.read(3)).to eq "Hel"
+      expect(composite_io.read(2)).to eq "lo"
+      expect(composite_io.read(1)).to eq " "
+      expect(composite_io.read(6)).to eq "world!"
+    end
+
+    it "returns empty string when no data was retrieved" do
+      composite_io.read
+      expect(composite_io.read).to eq ""
+    end
+
+    it "returns nil when no partial data was retrieved" do
+      composite_io.read
+      expect(composite_io.read(3)).to eq nil
+    end
+
+    it "reads partial data with a buffer" do
+      outbuf = String.new
+      expect(composite_io.read(3, outbuf)).to eq "Hel"
+      expect(composite_io.read(2, outbuf)).to eq "lo"
+      expect(composite_io.read(1, outbuf)).to eq " "
+      expect(composite_io.read(6, outbuf)).to eq "world!"
+    end
+
+    it "fills the buffer with retrieved content" do
+      outbuf = String.new
+      composite_io.read(3, outbuf)
+      expect(outbuf).to eq "Hel"
+      composite_io.read(2, outbuf)
+      expect(outbuf).to eq "lo"
+      composite_io.read(1, outbuf)
+      expect(outbuf).to eq " "
+      composite_io.read(6, outbuf)
+      expect(outbuf).to eq "world!"
+    end
+
+    it "returns nil when no partial data was retrieved with a buffer" do
+      outbuf = String.new("content")
+      composite_io.read
+      expect(composite_io.read(3, outbuf)).to eq nil
+      expect(outbuf).to eq ""
+    end
+  end
+
+  describe "#rewind" do
+    it "rewinds all IOs" do
+      composite_io.read
+      composite_io.rewind
+      expect(composite_io.read).to eq "Hello world!"
+    end
+  end
+
+  describe "#size" do
+    it "returns sum of all IO sizes" do
+      expect(composite_io.size).to eq 12
+    end
+
+    it "returns 0 when there are no IOs" do
+      empty_composite_io = HTTP::FormData::CompositeIO.new
+      expect(empty_composite_io.size).to eq 0
+    end
+  end
+end

--- a/spec/lib/http/form_data/composite_io_spec.rb
+++ b/spec/lib/http/form_data/composite_io_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe HTTP::FormData::CompositeIO do
   let(:ios) { ["Hello", " ", "", "world", "!"].map { |s| StringIO.new(s) } }
-  subject(:composite_io) { HTTP::FormData::CompositeIO.new(*ios) }
+  subject(:composite_io) { HTTP::FormData::CompositeIO.new(ios) }
 
   describe "#read" do
     it "reads all data" do
@@ -68,7 +68,7 @@ RSpec.describe HTTP::FormData::CompositeIO do
     end
 
     it "returns 0 when there are no IOs" do
-      empty_composite_io = HTTP::FormData::CompositeIO.new
+      empty_composite_io = HTTP::FormData::CompositeIO.new []
       expect(empty_composite_io.size).to eq 0
     end
   end

--- a/spec/lib/http/form_data/composite_io_spec.rb
+++ b/spec/lib/http/form_data/composite_io_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe HTTP::FormData::CompositeIO do
-  let(:ios) { ["Hello", " ", "", "world", "!"].map { |string| StringIO.new(string) } }
-  subject(:composite_io) { HTTP::FormData::CompositeIO.new *ios }
+  let(:ios) { ["Hello", " ", "", "world", "!"].map { |s| StringIO.new(s) } }
+  subject(:composite_io) { HTTP::FormData::CompositeIO.new(*ios) }
 
   describe "#read" do
     it "reads all data" do

--- a/spec/lib/http/form_data/composite_io_spec.rb
+++ b/spec/lib/http/form_data/composite_io_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe HTTP::FormData::CompositeIO do
   let(:ios) { ["Hello", " ", "", "world", "!"].map { |s| StringIO.new(s) } }
   subject(:composite_io) { HTTP::FormData::CompositeIO.new(ios) }
 
+  describe "#initialize" do
+    it "accepts IOs and strings" do
+      composite_io = HTTP::FormData::CompositeIO.new ["Hello ", StringIO.new("world!")]
+      expect(composite_io.read).to eq "Hello world!"
+    end
+
+    it "fails if an IO is neither a String nor an IO" do
+      expect { HTTP::FormData::CompositeIO.new [:hello, :world] }
+        .to raise_error(ArgumentError)
+    end
+  end
+
   describe "#read" do
     it "reads all data" do
       expect(composite_io.read).to eq "Hello world!"

--- a/spec/lib/http/form_data/file_spec.rb
+++ b/spec/lib/http/form_data/file_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe HTTP::FormData::File do
       it { is_expected.to eq fixture("the-http-gem.info").size }
     end
 
-    context "when file given as StringIO" do
-      let(:file) { StringIO.new "привет мир!" }
-      it { is_expected.to eq 20 }
-    end
-
     context "when file given as File" do
       let(:file) { fixture("the-http-gem.info").open }
       after { file.close }
       it { is_expected.to eq fixture("the-http-gem.info").size }
+    end
+
+    context "when file given as IO" do
+      let(:file) { StringIO.new "привет мир!" }
+      it { is_expected.to eq 20 }
     end
   end
 
@@ -32,15 +32,15 @@ RSpec.describe HTTP::FormData::File do
       it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
     end
 
-    context "when file given as StringIO" do
-      let(:file) { StringIO.new "привет мир!" }
-      it { is_expected.to eq "привет мир!" }
-    end
-
     context "when file given as File" do
       let(:file) { fixture("the-http-gem.info").open("rb") }
       after { file.close }
       it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+    end
+
+    context "when file given as IO" do
+      let(:file) { StringIO.new "привет мир!" }
+      it { is_expected.to eq "привет мир!" }
     end
   end
 
@@ -58,10 +58,11 @@ RSpec.describe HTTP::FormData::File do
       end
     end
 
-    context "when file given as StringIO" do
-      let(:file) { StringIO.new }
+    context "when file given as File" do
+      let(:file) { fixture("the-http-gem.info").open }
+      after { file.close }
 
-      it { is_expected.to eq "stream-#{file.object_id}" }
+      it { is_expected.to eq "the-http-gem.info" }
 
       context "and filename given with options" do
         let(:opts) { { :filename => "foobar.txt" } }
@@ -69,11 +70,10 @@ RSpec.describe HTTP::FormData::File do
       end
     end
 
-    context "when file given as File" do
-      let(:file) { fixture("the-http-gem.info").open }
-      after { file.close }
+    context "when file given as IO" do
+      let(:file) { StringIO.new }
 
-      it { is_expected.to eq "the-http-gem.info" }
+      it { is_expected.to eq "stream-#{file.object_id}" }
 
       context "and filename given with options" do
         let(:opts) { { :filename => "foobar.txt" } }

--- a/spec/lib/http/form_data/file_spec.rb
+++ b/spec/lib/http/form_data/file_spec.rb
@@ -54,6 +54,76 @@ RSpec.describe HTTP::FormData::File do
     end
   end
 
+  describe "#read" do
+    subject { described_class.new(file, opts).read }
+
+    context "when file given as a String" do
+      let(:file) { fixture("the-http-gem.info").to_s }
+      it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+    end
+
+    context "when file given as a Pathname" do
+      let(:file) { fixture("the-http-gem.info") }
+      it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+    end
+
+    context "when file given as File" do
+      let(:file) { fixture("the-http-gem.info").open("rb") }
+      after { file.close }
+      it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+    end
+
+    context "when file given as IO" do
+      let(:file) { StringIO.new "привет мир!" }
+      it { is_expected.to eq "привет мир!" }
+    end
+  end
+
+  describe "#rewind" do
+    subject { described_class.new(file, opts) }
+
+    context "when file given as a String" do
+      let(:file) { fixture("the-http-gem.info").to_s }
+
+      it "rewinds the underlying IO object" do
+        subject.read
+        subject.rewind
+        expect(subject.read).to eq fixture("the-http-gem.info").read(:mode => "rb")
+      end
+    end
+
+    context "when file given as a Pathname" do
+      let(:file) { fixture("the-http-gem.info") }
+
+      it "rewinds the underlying IO object" do
+        subject.read
+        subject.rewind
+        expect(subject.read).to eq fixture("the-http-gem.info").read(:mode => "rb")
+      end
+    end
+
+    context "when file given as File" do
+      let(:file) { fixture("the-http-gem.info").open("rb") }
+      after { file.close }
+
+      it "rewinds the underlying IO object" do
+        subject.read
+        subject.rewind
+        expect(subject.read).to eq fixture("the-http-gem.info").read(:mode => "rb")
+      end
+    end
+
+    context "when file given as IO" do
+      let(:file) { StringIO.new "привет мир!" }
+
+      it "rewinds the underlying IO object" do
+        subject.read
+        subject.rewind
+        expect(subject.read).to eq "привет мир!"
+      end
+    end
+  end
+
   describe "#filename" do
     subject { described_class.new(file, opts).filename }
 

--- a/spec/lib/http/form_data/file_spec.rb
+++ b/spec/lib/http/form_data/file_spec.rb
@@ -86,9 +86,9 @@ RSpec.describe HTTP::FormData::File do
       let(:file) { fixture("the-http-gem.info").to_s }
 
       it "rewinds the underlying IO object" do
-        subject.read
+        content = subject.read
         subject.rewind
-        expect(subject.read).to eq fixture("the-http-gem.info").read(:mode => "rb")
+        expect(subject.read).to eq content
       end
     end
 
@@ -96,9 +96,9 @@ RSpec.describe HTTP::FormData::File do
       let(:file) { fixture("the-http-gem.info") }
 
       it "rewinds the underlying IO object" do
-        subject.read
+        content = subject.read
         subject.rewind
-        expect(subject.read).to eq fixture("the-http-gem.info").read(:mode => "rb")
+        expect(subject.read).to eq content
       end
     end
 
@@ -107,9 +107,9 @@ RSpec.describe HTTP::FormData::File do
       after { file.close }
 
       it "rewinds the underlying IO object" do
-        subject.read
+        content = subject.read
         subject.rewind
-        expect(subject.read).to eq fixture("the-http-gem.info").read(:mode => "rb")
+        expect(subject.read).to eq content
       end
     end
 
@@ -117,9 +117,9 @@ RSpec.describe HTTP::FormData::File do
       let(:file) { StringIO.new "привет мир!" }
 
       it "rewinds the underlying IO object" do
-        subject.read
+        content = subject.read
         subject.rewind
-        expect(subject.read).to eq "привет мир!"
+        expect(subject.read).to eq content
       end
     end
   end

--- a/spec/lib/http/form_data/file_spec.rb
+++ b/spec/lib/http/form_data/file_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe HTTP::FormData::File do
       it { is_expected.to eq fixture("the-http-gem.info").size }
     end
 
+    context "when file given as a Pathname" do
+      let(:file) { fixture("the-http-gem.info") }
+      it { is_expected.to eq fixture("the-http-gem.info").size }
+    end
+
     context "when file given as File" do
       let(:file) { fixture("the-http-gem.info").open }
       after { file.close }
@@ -32,6 +37,11 @@ RSpec.describe HTTP::FormData::File do
       it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
     end
 
+    context "when file given as a Pathname" do
+      let(:file) { fixture("the-http-gem.info") }
+      it { is_expected.to eq fixture("the-http-gem.info").read(:mode => "rb") }
+    end
+
     context "when file given as File" do
       let(:file) { fixture("the-http-gem.info").open("rb") }
       after { file.close }
@@ -49,6 +59,17 @@ RSpec.describe HTTP::FormData::File do
 
     context "when file given as a String" do
       let(:file) { fixture("the-http-gem.info").to_s }
+
+      it { is_expected.to eq ::File.basename file }
+
+      context "and filename given with options" do
+        let(:opts) { { :filename => "foobar.txt" } }
+        it { is_expected.to eq "foobar.txt" }
+      end
+    end
+
+    context "when file given as a Pathname" do
+      let(:file) { fixture("the-http-gem.info") }
 
       it { is_expected.to eq ::File.basename file }
 

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe HTTP::FormData::Multipart do
     end
 
     context "with filename set to nil" do
-      let(:part) { HTTP::FormData::Part.new("s", :content_type => "text/plain") }
+      let(:part) { HTTP::FormData::Part.new("s", :content_type => "mime/type") }
       let(:form_data) { HTTP::FormData::Multipart.new(:foo => part) }
 
       it "doesn't include a filename" do

--- a/spec/lib/http/form_data/multipart_spec.rb
+++ b/spec/lib/http/form_data/multipart_spec.rb
@@ -6,19 +6,6 @@ RSpec.describe HTTP::FormData::Multipart do
   let(:boundary)      { /-{21}[a-f0-9]{42}/ }
   subject(:form_data) { HTTP::FormData::Multipart.new params }
 
-  describe "#content_type" do
-    subject { form_data.content_type }
-
-    let(:content_type) { %r{^multipart\/form-data; boundary=#{boundary}$} }
-
-    it { is_expected.to match(content_type) }
-  end
-
-  describe "#content_length" do
-    subject { form_data.content_length }
-    it { is_expected.to eq form_data.to_s.bytesize }
-  end
-
   describe "#to_s" do
     def disposition(params)
       params = params.map { |k, v| "#{k}=#{v.inspect}" }.join("; ")
@@ -36,14 +23,31 @@ RSpec.describe HTTP::FormData::Multipart do
         "#{crlf}bar#{crlf}",
         "--#{boundary_value}#{crlf}",
         "#{disposition 'name' => 'baz', 'filename' => file.filename}#{crlf}",
-        "Content-Type: #{file.mime_type}#{crlf}",
+        "Content-Type: #{file.content_type}#{crlf}",
         "#{crlf}#{file}#{crlf}",
         "--#{boundary_value}--"
       ].join("")
     end
 
     context "with filename set to nil" do
-      let(:part) { HTTP::FormData::Part.new("s", :filename => nil) }
+      let(:part) { HTTP::FormData::Part.new("s", :content_type => "text/plain") }
+      let(:form_data) { HTTP::FormData::Multipart.new(:foo => part) }
+
+      it "doesn't include a filename" do
+        boundary_value = form_data.content_type[/(#{boundary})$/, 1]
+
+        expect(form_data.to_s).to eq [
+          "--#{boundary_value}#{crlf}",
+          "#{disposition 'name' => 'foo'}#{crlf}",
+          "Content-Type: #{part.content_type}#{crlf}",
+          "#{crlf}s#{crlf}",
+          "--#{boundary_value}--"
+        ].join("")
+      end
+    end
+
+    context "with content type set to nil" do
+      let(:part) { HTTP::FormData::Part.new("s") }
       let(:form_data) { HTTP::FormData::Multipart.new(:foo => part) }
 
       it "doesn't include a filename" do
@@ -57,5 +61,38 @@ RSpec.describe HTTP::FormData::Multipart do
         ].join("")
       end
     end
+  end
+
+  describe "#size" do
+    it "returns bytesize of multipart data" do
+      expect(form_data.size).to eq form_data.to_s.bytesize
+    end
+  end
+
+  describe "#read" do
+    it "returns multipart data" do
+      expect(form_data.read).to eq form_data.to_s
+    end
+  end
+
+  describe "#rewind" do
+    it "rewinds the multipart data IO" do
+      form_data.read
+      form_data.rewind
+      expect(form_data.read).to eq form_data.to_s
+    end
+  end
+
+  describe "#content_type" do
+    subject { form_data.content_type }
+
+    let(:content_type) { %r{^multipart\/form-data; boundary=#{boundary}$} }
+
+    it { is_expected.to match(content_type) }
+  end
+
+  describe "#content_length" do
+    subject { form_data.content_length }
+    it { is_expected.to eq form_data.to_s.bytesize }
   end
 end

--- a/spec/lib/http/form_data/part_spec.rb
+++ b/spec/lib/http/form_data/part_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe HTTP::FormData::Part do
-  let(:body) { "" }
-  let(:opts) { {} }
+  let(:body)     { "" }
+  let(:opts)     { {} }
+  subject(:part) { HTTP::FormData::Part.new(body, opts) }
 
   describe "#size" do
-    subject { described_class.new(body, opts).size }
+    subject { part.size }
 
     context "when body given as a String" do
       let(:body) { "привет мир!" }
@@ -14,7 +15,7 @@ RSpec.describe HTTP::FormData::Part do
   end
 
   describe "#to_s" do
-    subject { described_class.new(body, opts).to_s }
+    subject! { part.to_s }
 
     context "when body given as String" do
       let(:body) { "привет мир!" }
@@ -22,8 +23,29 @@ RSpec.describe HTTP::FormData::Part do
     end
   end
 
+  describe "#read" do
+    subject { part.read }
+
+    context "when body given as String" do
+      let(:body) { "привет мир!" }
+      it { is_expected.to eq "привет мир!" }
+    end
+  end
+
+  describe "#rewind" do
+    context "when body given as String" do
+      let(:body) { "привет мир!" }
+
+      it "rewinds the underlying IO object" do
+        part.read
+        part.rewind
+        expect(part.read).to eq "привет мир!"
+      end
+    end
+  end
+
   describe "#filename" do
-    subject { described_class.new(body, opts).filename }
+    subject { part.filename }
 
     it { is_expected.to eq nil }
 
@@ -34,7 +56,7 @@ RSpec.describe HTTP::FormData::Part do
   end
 
   describe "#content_type" do
-    subject { described_class.new(body, opts).content_type }
+    subject { part.content_type }
 
     it { is_expected.to eq nil }
 

--- a/spec/lib/http/form_data_spec.rb
+++ b/spec/lib/http/form_data_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe HTTP::FormData do
 
     context "when form has at least one file param" do
       let(:file) { HTTP::FormData::File.new(fixture("the-http-gem.info").to_s) }
-      let(:params)  { { :foo => :bar, :baz => file } }
+      let(:params) { { :foo => :bar, :baz => file } }
       it { is_expected.to be_a HTTP::FormData::Multipart }
     end
 
     context "when form has file in an array param" do
       let(:file) { HTTP::FormData::File.new(fixture("the-http-gem.info").to_s) }
-      let(:params)  { { :foo => :bar, :baz => [file] } }
+      let(:params) { { :foo => :bar, :baz => [file] } }
       it { is_expected.to be_a HTTP::FormData::Multipart }
     end
   end

--- a/spec/lib/http/form_data_spec.rb
+++ b/spec/lib/http/form_data_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe HTTP::FormData do
     end
 
     context "when form has at least one file param" do
-      let(:gemspec) { HTTP::FormData::File.new "gemspec" }
-      let(:params)  { { :foo => :bar, :baz => gemspec } }
+      let(:file) { HTTP::FormData::File.new(fixture("the-http-gem.info").to_s) }
+      let(:params)  { { :foo => :bar, :baz => file } }
       it { is_expected.to be_a HTTP::FormData::Multipart }
     end
 
     context "when form has file in an array param" do
-      let(:gemspec) { HTTP::FormData::File.new "gemspec" }
-      let(:params)  { { :foo => :bar, :baz => [gemspec] } }
+      let(:file) { HTTP::FormData::File.new(fixture("the-http-gem.info").to_s) }
+      let(:params)  { { :foo => :bar, :baz => [file] } }
       it { is_expected.to be_a HTTP::FormData::Multipart }
     end
   end


### PR DESCRIPTION
This pull request allows multipart data to be streamed into the request body using the new streaming API in HTTP.rb (https://github.com/httprb/http/pull/409). The advantage of streaming is that, when File parts are backed by files on the filesystem, multipart data doesn't have to be loaded whole into memory before its sent as the request body, but rather only small parts will be loaded into memory at a time.

First I needed to modify `FormData::File` to support any IO object, not just `File` or `StringIO`, so that the logic can be simpler. I think this feature is useful in general, as explained in https://github.com/httprb/http/pull/409#issuecomment-298356867.

I also modified the File object to be opened in binary mode, to prevent any conversions of carriage returns and line feeds by different operating systems. This is not related to this PR, but I noticed it and wanted to do it so that I don't forget.

`FormData::File` has implicitly supported `Pathname` objects (which is used in tests), but the previous refactoring has forced me to make this support explicit. I think that's good, since some folks might be relying on it, and it's nice to support `Pathname` for file paths in general.

Finally, I modified all components to be backed by an IO object, so that they can all implement a common IO interface (`FormData::Readable`), enabling them to be composed using `CompositeIO`. Most of the `CompositeIO` implementation was borrowed from [`multipart-post`](https://github.com/nicksieger/multipart-post). I needed to include `#rewind` in the interface so that `#to_s` can be called multiple times.